### PR TITLE
Drop nargs for dir parameter

### DIFF
--- a/trustme_cli.py
+++ b/trustme_cli.py
@@ -16,7 +16,6 @@ def main(argv: typing.Sequence[str] = None) -> None:
     parser.add_argument(
         "-d",
         "--dir",
-        nargs=1,
         default=os.getcwd(),
         help="Directory where certificates and keys are written to. Defaults to cwd",
     )


### PR DESCRIPTION
Hey @sethmlarson :-)

I was trying to generate cert files in a local directory via

```bash
trustme-cli -d ./debug
```

And got the following error:

```console
Traceback (most recent call last):
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/bin/trustme-cli", line 8, in <module>
    sys.exit(main())
  File "/Users/florimond.manca/go/src/github.com/DataDog/integrations-core/venv/lib/python3.8/site-packages/trustme_cli.py", line 53, in main
    cert_dir = pathlib.Path(args.dir)
  File "/Users/florimond.manca/.pyenv/versions/3.8.5/lib/python3.8/pathlib.py", line 1038, in __new__
    self = cls._from_parts(args, init=False)
  File "/Users/florimond.manca/.pyenv/versions/3.8.5/lib/python3.8/pathlib.py", line 679, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/Users/florimond.manca/.pyenv/versions/3.8.5/lib/python3.8/pathlib.py", line 663, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not list
```

Comes from defining `nargs=1` and yet using `Path(args.dir)` (instead of `Path(args.dir[0])`). I don't think we intended to allow passing multiple `dir` values, so I removed the `nargs` in this PR. :-)